### PR TITLE
Add oauth.certificate path to certificate extraction

### DIFF
--- a/check-cf-certificate-expiration/catalog.json
+++ b/check-cf-certificate-expiration/catalog.json
@@ -61,7 +61,7 @@
           {
             "execute": "utils-sapcp:Void:1",
             "input": {
-              "message": "$(.getBindingCredentials.output.outputs\n   | map({ id: .bindingId, instanceName: .instanceName, certificate: .credentials.certificate // .credentials.clientcert // .credentials.sslcert // .credentials.uaa.certificate // .credentials.x509.certificate })\n   | filter(.certificate != null)\n)"
+              "message": "$(.getBindingCredentials.output.outputs\n   | map({ id: .bindingId, instanceName: .instanceName, certificate: .credentials.certificate // .credentials.clientcert // .credentials.sslcert // .credentials.uaa.certificate // .credentials.x509.certificate // .credentials.oauth.certificate })\n   | filter(.certificate != null)\n)"
             },
             "alias": "extractCertificates",
             "description": "Extract certificates from binding credentials",


### PR DESCRIPTION
Extend the certificate expiration check to also look for certificates in .credentials.oauth.certificate for service bindings.