### PR TITLE
Add SAP HANA Cloud Lifecycle Management example

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,3 @@
 developers.sap.com
+community.sap.com
+help.sap.com

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -116,17 +116,17 @@ community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.1, available at
-[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct/][v2.1].
 
 Community Impact Guidelines were inspired by
 [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
 
 For answers to common questions about this code of conduct, see the FAQ at
-[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
-[https://www.contributor-covenant.org/translations][translations].
+[https://www.contributor-covenant.org/faq/][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations/][translations].
 
 [homepage]: https://www.contributor-covenant.org
-[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[Mozilla CoC]: https://github.com/mozilla/diversity
-[FAQ]: https://www.contributor-covenant.org/faq
-[translations]: https://www.contributor-covenant.org/translations
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+[Mozilla CoC]: https://github.com/mozilla/inclusion
+[FAQ]: https://www.contributor-covenant.org/faq/
+[translations]: https://www.contributor-covenant.org/translations/

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ These examples are provided **as-is**. Support is available through the communit
 To use the examples in this repository, you'll need access to SAP Automation Pilot. Here are the different ways to get started:
 
 * [Tutorial: Get a Free Account on SAP BTP Trial](https://developers.sap.com/tutorials/hcp-create-trial-account.html)
-* [Tutorial: Setup Automation Pilot in SAP BTP](https://blogs.sap.com/2023/01/09/setup-configuration-of-automation-pilot-in-btp-cockpit/)
+* [Tutorial: Setup Automation Pilot in SAP BTP](https://help.sap.com/docs/automation-pilot/automation-pilot/initial-setup?locale=en-US&version=Cloud)
 * [Official Documentation](https://help.sap.com/docs/AUTOMATION_PILOT?locale=en-US)
 * [Discovery Center Overview](https://discovery-center.cloud.sap/serviceCatalog/automation-pilot)
 * [API Reference](https://api.sap.com/package/SAPCloudPlatformAutomationPilot/overview)
@@ -77,7 +77,7 @@ To use the examples in this repository, you'll need access to SAP Automation Pil
 * [YouTube: Automation Pilot Overview](https://www.youtube.com/live/SpitmcdQVGU)
 * [YouTube: HANA Cloud Automation](https://www.youtube.com/watch?v=JD16pX1-kzc)
 * [YouTube: Technical Ops Automations](https://www.youtube.com/watch?v=dDoU2oVBgg0)
-* [Community Blog Posts](https://blogs.sap.com/tags/73554900100800002433/)
+* [Community Blog Posts](https://community.sap.com/t5/c-khhcw49343/SAP+Automation+Pilot/pd-p/73554900100800002433)
 
 ## Getting Started
 
@@ -116,6 +116,7 @@ After successful import, you'll see a new catalog tile labeled **"Automation Pil
 
 | Example | Description |
 |---------|-------------|
+| [HANA Cloud Lifecycle Management](hana-lifecycle-management) | Comprehensive lifecycle management for HANA Cloud instances in the Other Environment (subaccount level) with 31 commands covering instance operations, backup & recovery, snapshots, configuration, upgrades, and Elastic Compute Nodes (ECN) |
 | [Update HANA Cloud](update-hana-cloud) | Automatically update the HANA Cloud database to the latest patch version, to the next or most recent QRC version |
 | [Mass Stop/Start HANA Cloud](mass-stop-start-hana-cloud) | Stop or start all HANA Cloud databases across your entire BTP account |
 | [Check HANA Cloud Backup](check-hana-cloud-backup) | Check regularly whether there was a recent backup of a SAP HANA Cloud database |
@@ -199,7 +200,7 @@ After successful import, you'll see a new catalog tile labeled **"Automation Pil
 
 [Create an issue](https://github.com/SAP-samples/automation-pilot-examples/issues) in this repository if you find a bug or have questions about the content.
 
-For additional support, [ask a question in SAP Community](https://answers.sap.com/questions/ask.html).
+For additional support, [ask a question in SAP Community](https://community.sap.com/t5/forums/postpage/category-id/products/choose-node/true).
 
 ## Contributing
 

--- a/auto-scale-neo-app/README.md
+++ b/auto-scale-neo-app/README.md
@@ -12,7 +12,7 @@ BTP Neo this does not provide a full-fledged and flexible autoscaling option. Th
 
 Furthermore, with the help of SAP Alert Notification this command can be automatically triggered whenever the CPU load metric of your application instance reaches a critical level.
 
-This example is described in further details by this blog post: [Application autoscaling with Automation Pilot and Alert Notification](https://blogs.sap.com/2021/06/04/application-autoscaling-with-automation-pilot-and-alert-notification-in-sap-btp-neo-environment/)
+This example is described in further details by this blog post: [Application autoscaling with Automation Pilot and Alert Notification](https://community.sap.com/t5/technology-blog-posts-by-sap/application-autoscaling-with-automation-pilot-and-alert-notification-in-sap/ba-p/13520281)
 
 ## Requirements
 

--- a/backup-catalog/README.md
+++ b/backup-catalog/README.md
@@ -32,9 +32,9 @@ To use this example you'll need the following:
 
 Check out the following resources for more information:
 
-* [Create a GitHub repository](https://docs.github.com/en/get-started/quickstart/create-a-repo)
+* [Create a GitHub repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/quickstart-for-repositories)
 * [Managing teams and people with access to your GitHub repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-teams-and-people-with-access-to-your-repository)
-* [Creating a GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+* [Creating a GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
 * [Managing Automation Pilot Service Accounts](https://help.sap.com/docs/AUTOMATION_PILOT/de3900c419f5492a8802274c17e07049/91713d7e71624dbf92ea43f5faf810e5.html)
 
 ## How to use

--- a/check-hana-cloud-availability/README.md
+++ b/check-hana-cloud-availability/README.md
@@ -46,7 +46,7 @@ Check out the following resources for more information:
 * [Provision an Instance of SAP HANA Cloud, SAP HANA Database](https://developers.sap.com/tutorials/hana-cloud-mission-trial-3.html) on a runtime environment set to Cloud Foundry;
 * [Deploy SAP HANA Cloud](https://developers.sap.com/tutorials/hana-cloud-deploying.html);
 * [Create Users and Manage Roles and Privileges](https://developers.sap.com/tutorials/hana-cloud-mission-trial-4.html);
-* [Managing technical users for BTP platform access](https://blogs.sap.com/2022/09/20/managing-technical-users-for-btp-platform-access/);
+* [Managing technical users for BTP platform access](https://community.sap.com/t5/technology-blog-posts-by-members/managing-technical-users-for-btp-platform-access/ba-p/13521814);
 * [Overview of Available Metrics](https://help.sap.com/docs/HANA_CLOUD_DATABASE/f9c5015e72e04fffa14d7d4f7267d897/46e370ced3ef4d2bbd0ec2337df5f565.html);
 * [Alert Notification service initial setup](https://help.sap.com/docs/alert-notification/sap-alert-notification-for-sap-btp/initial-setup) ;
 * [Integrate your Automaton Pilot instance to the Alert Notification service](https://help.sap.com/docs/automation-pilot/automation-pilot/integrate-with-sap-alert-notification-service-for-sap-btp);

--- a/hana-lifecycle-management/README.md
+++ b/hana-lifecycle-management/README.md
@@ -1,0 +1,140 @@
+# SAP HANA Cloud Lifecycle Management
+
+![Automating SAP HANA Cloud Workloads](assets/diagram.svg)
+
+Table of Contents
+
+* [Description](#description)
+* [Requirements](#requirements)
+* [Available Commands](#available-commands)
+* [How to use](#how-to-use)
+
+## Description
+
+This catalog provides a comprehensive set of lifecycle management commands for SAP HANA Cloud instances in the *Other Environment* (subaccount level) using Service Manager. These commands enable you to automate all aspects of HANA Cloud database management, including:
+
+* **Instance Management**: Create, delete, start, stop, and recover HANA Cloud instances
+* **Configuration**: Update instance size, allowed connections, and backup settings
+* **Upgrades & Updates**: Upgrade instances to new versions and enable capabilities
+* **Snapshots**: Create, list, delete, and revert to snapshots
+* **Backup & Recovery**: Manage backups and recover instances from backup
+* **Extended Compute Nodes (ECN)**: Create, update, list, and delete ECNs
+* **System Operations**: Copy instances, install plugins, and manage takeover operations
+
+All commands in this catalog use the SAP Service Manager API to manage HANA Cloud instances, providing a consistent and automated approach to database lifecycle management.
+
+## Requirements
+
+To use this example you'll need the following:
+
+* HANA Cloud database in the *Other environment* (subaccount level)
+* Instance of [SAP Service Manager](https://help.sap.com/docs/service-manager/sap-service-manager/sap-service-manager) with plan *subaccount-admin* and a service key
+
+Check out the following resources for more information:
+
+* [SAP Service Manager Documentation](https://help.sap.com/docs/service-manager/sap-service-manager/sap-service-manager)
+* [HANA Cloud Administration Guide](https://help.sap.com/docs/HANA_CLOUD)
+
+## Available Commands
+
+This catalog includes 31 commands for comprehensive HANA Cloud lifecycle management:
+
+### Instance Lifecycle Management
+
+| Command | Description |
+|---------|-------------|
+| **CreateHanaCloudInstance** | Provisions a new SAP HANA Cloud Database instance with specified configuration including memory, storage, and network access settings |
+| **DeleteHanaCloudInstance** | Permanently deletes a HANA Cloud instance and all its data (irreversible, backups retained per policy) |
+| **StartHanaCloudInstance** | Starts a stopped HANA Cloud instance (typically takes 5-10 minutes) |
+| **StopHanaCloudInstance** | Gracefully stops a running HANA Cloud instance to reduce costs while preserving data (typically takes 2-5 minutes) |
+| **RestartHanaCloudInstance** | Restarts a HANA Cloud instance by stopping and starting it (useful for applying changes or troubleshooting, takes 10-15 minutes) |
+| **GetHanaCloudInstance** | Retrieves detailed information about a HANA Cloud instance including status, configuration, labels, and connection details |
+| **ListHanaCloudInstances** | Retrieves a list of all HANA Cloud instances in the subaccount with their current status and metadata |
+| **CopyHanaCloudInstance** | Creates a copy of a HANA Cloud instance at a given point in time to a new instance (supports same or cross-subaccount) |
+
+### Backup & Recovery
+
+| Command | Description |
+|---------|-------------|
+| **RecoverHanaCloudInstance** | Restores a HANA Cloud instance to a specific point in time using available backups and transaction logs |
+| **RecreateHanaCloudInstanceFromBackup** | Recreates a HANA Cloud instance from backup for disaster recovery (same or different availability zone) |
+| **StartHanaCloudInstanceTakeover** | Initiates failover to a replica (supports synchronous replication or disaster recovery takeover) |
+| **UpdateHanaCloudBackupSettings** | Updates the backup retention policy (affects storage costs and point-in-time recovery capabilities) |
+
+### Snapshot Management
+
+| Command | Description |
+|---------|-------------|
+| **CreateHanaCloudSnapshot** | Creates a snapshot for version rollback (only one snapshot allowed per instance, auto-deleted after 14 days) |
+| **ListHanaCloudSnapshots** | Retrieves all available storage snapshots with size, version, ID, and timestamp information |
+| **DeleteHanaCloudSnapshot** | Deletes a specific snapshot before automatic expiration |
+| **DeleteOldestHanaCloudSnapshot** | Automatically identifies and deletes the oldest snapshot by creation timestamp |
+| **RevertHanaCloudToSnapshot** | Rolls back instance to a previous snapshot (requires downtime, typically 20-40 minutes, irreversible) |
+
+### Instance Configuration
+
+| Command | Description |
+|---------|-------------|
+| **UpdateHanaCloudInstanceSize** | Modifies compute and storage resources (memory/vCPU changes require restart, storage can only increase) |
+| **UpdateHanaCloudInstanceAllowedConnections** | Configures IP filter rules controlling which addresses can connect (immediate effect, no restart) |
+| **EnableHanaCloudConnectivityProxy** | Enables/disables Cloud Connector connectivity allowing on-premise SAP HANA to connect to cloud and replicate data |
+| **UpdateHanaCloudBackupSettings** | Updates the backup retention policy (affects storage costs and point-in-time recovery capabilities) |
+| **EnableHanaCloudCapabilities** | Enables/disables capabilities: scriptserver, docstore, dpserver, PAL, NLP, triplestore (some require +16 GB memory) |
+
+### Upgrades & Plugins
+
+| Command | Description |
+|---------|-------------|
+| **UpgradeHanaCloudInstance** | Upgrades instance to a newer version within release cycle and track (cannot downgrade, patches available for 7 months) |
+| **ListHanaCloudAvailableUpgradeVersions** | Retrieves current version and available upgrade versions with maintenance status |
+| **InstallHanaCloudPlugins** | Installs plugins to extend database functionality with additional capabilities |
+| **ListHanaCloudPlugins** | Retrieves all installed plugins with their name and status information |
+
+### Elastic Compute Nodes (ECN)
+
+| Command | Description |
+|---------|-------------|
+| **CreateHanaCloudECN** | Creates a single Elastic Compute Node to provide additional compute resources for query processing |
+| **CreateMultipleHanaCloudECNs** | Creates multiple ECNs in a single operation for scaled query processing capacity |
+| **UpdateHanaCloudECN** | Updates ECN configuration (vCPU, memory 32GB-6TB in 15GB increments, storage) |
+| **ListHanaCloudECNs** | Retrieves all ECNs with their vCPU, memory, and storage configuration details |
+| **DeleteHanaCloudECN** | Deletes a specific ECN by name while keeping other ECNs active |
+| **DeleteAllHanaCloudECNs** | Deletes all ECNs from an instance (use with caution, cannot be undone) |
+
+## How to use
+
+Import the content of [examples catalog](catalog.json) in your Automation Pilot tenant. Navigate to the desired command and trigger it.
+
+### Common Input Parameters
+
+Most commands in this catalog require the following input parameters:
+
+* **serviceKey** - Service key to the SAP Service Manager with plan *subaccount-admin*. This is a sensitive object containing authentication credentials
+* **instanceId** - The unique identifier (GUID) or display name of the HANA Cloud instance
+
+### Example: Starting a HANA Cloud Instance
+
+To start a HANA Cloud instance, navigate to the *StartHanaCloudInstance* command and provide:
+
+* **serviceKey** - Your Service Manager service key (object)
+* **instanceId** - The ID or name of your HANA Cloud instance
+* **deadline** - Optional: Maximum time to wait for the operation to complete (in seconds)
+
+### Example: Creating a Snapshot
+
+To create a snapshot of your HANA Cloud instance, use the *CreateHanaCloudSnapshot* command with:
+
+* **serviceKey** - Your Service Manager service key (object)
+* **instanceId** - The ID or name of your HANA Cloud instance
+
+### Example: Copying a HANA Cloud Instance
+
+To copy a HANA Cloud instance to a new instance at a specific point in time, use the *CopyHanaCloudInstance* command with:
+
+* **targetInstanceId** - The unique identifier (GUID) or display name of the target HANA Cloud instance that will receive the copy
+* **sourceInstanceId** - The identifier of the source HANA Cloud instance (can be name or ID for same subaccount, must be GUID/UID for cross-subaccount)
+* **targetTimestamp** - The point-in-time timestamp to restore data from (format: YYYY-MM-DD HH:MM:SS)
+* **serviceKey** - Your Service Manager service key (object)
+* **deadline** - Optional: Maximum time to wait for the operation to complete
+
+:information_source: **Note**: Each command has specific input parameters tailored to its operation. Review the command details in the Automation Pilot UI for complete parameter documentation.

--- a/hana-lifecycle-management/assets/diagram.svg
+++ b/hana-lifecycle-management/assets/diagram.svg
@@ -1,0 +1,267 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" width="100%" height="100%">
+  <defs>
+    <!-- Glow Filter for Data Packets and Active States -->
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="4" result="blur" />
+      <feComposite in="SourceGraphic" in2="blur" operator="over" />
+    </filter>
+    
+    <!-- SAP Blue Gradient -->
+    <linearGradient id="sapBlue" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#0284c7" />
+    </linearGradient>
+    
+    <!-- Background Tech Grid -->
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e293b" stroke-width="1"/>
+    </pattern>
+  </defs>
+
+  <!-- Background Base -->
+  <rect width="100%" height="100%" fill="#0f172a" rx="12"/>
+  <rect width="100%" height="100%" fill="url(#grid)" rx="12"/>
+
+  <!-- Subtle ambient glows behind main components -->
+  <circle cx="400" cy="200" r="90" fill="#8b5cf6" opacity="0.08" filter="url(#glow)"/>
+  <circle cx="660" cy="200" r="140" fill="#0ea5e9" opacity="0.05" filter="url(#glow)"/>
+
+  <!-- Titles -->
+  <text x="100" y="45" fill="#f8fafc" font-family="sans-serif" font-size="18" font-weight="bold" text-anchor="start">Automating SAP HANA Cloud Workloads</text>
+  <text x="100" y="65" fill="#94a3b8" font-family="sans-serif" font-size="13" text-anchor="start">Orchestrating databases efficiently using SAP Automation Pilot</text>
+
+  <!-- ============================================== -->
+  <!-- CONNECTION PATHS (Dashed Lines)                -->
+  <!-- ============================================== -->
+  <g fill="none" stroke="#334155" stroke-width="2" stroke-dasharray="4 4">
+    <!-- User to AutoPi -->
+    <path d="M 150 200 L 320 200" />
+    <!-- AutoPi to DB 1 (Start/Stop) -->
+    <path d="M 480 200 C 530 200, 540 90, 620 90" />
+    <!-- AutoPi to DB 2 (Backup) -->
+    <path d="M 480 200 C 530 200, 540 210, 620 210" />
+    <!-- AutoPi to DB 3 (Scale) -->
+    <path d="M 480 200 C 530 200, 540 330, 620 330" />
+  </g>
+
+  <!-- Connection Text Labels -->
+  <text x="235" y="185" fill="#e2e8f0" font-family="sans-serif" font-size="12" font-weight="bold" text-anchor="middle">Execute Workflow</text>
+  <text x="235" y="215" fill="#94a3b8" font-family="sans-serif" font-size="10" text-anchor="middle">API / Scheduler</text>
+
+
+  <!-- ============================================== -->
+  <!-- ANIMATED DATA PACKETS                          -->
+  <!-- ============================================== -->
+  
+  <!-- Packet 1: User to AutoPi -->
+  <circle r="5" fill="#38bdf8" filter="url(#glow)">
+    <animateMotion dur="5s" repeatCount="indefinite" path="M 150 200 L 320 200" keyPoints="0;1;1" keyTimes="0;0.2;1" calcMode="linear"/>
+    <animate attributeName="opacity" values="0;1;1;0;0" keyTimes="0;0.01;0.19;0.2;1" dur="5s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- Packet 2: AutoPi to DB 1 -->
+  <circle r="5" fill="#a78bfa" filter="url(#glow)">
+    <animateMotion dur="5s" repeatCount="indefinite" path="M 480 200 C 530 200, 540 90, 620 90" keyPoints="0;0;1;1" keyTimes="0;0.25;0.45;1" calcMode="linear"/>
+    <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.24;0.25;0.44;0.45;1" dur="5s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- Packet 3: AutoPi to DB 2 -->
+  <circle r="5" fill="#a78bfa" filter="url(#glow)">
+    <animateMotion dur="5s" repeatCount="indefinite" path="M 480 200 C 530 200, 540 210, 620 210" keyPoints="0;0;1;1" keyTimes="0;0.25;0.45;1" calcMode="linear"/>
+    <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.24;0.25;0.44;0.45;1" dur="5s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- Packet 4: AutoPi to DB 3 -->
+  <circle r="5" fill="#a78bfa" filter="url(#glow)">
+    <animateMotion dur="5s" repeatCount="indefinite" path="M 480 200 C 530 200, 540 330, 620 330" keyPoints="0;0;1;1" keyTimes="0;0.25;0.45;1" calcMode="linear"/>
+    <animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.24;0.25;0.44;0.45;1" dur="5s" repeatCount="indefinite"/>
+  </circle>
+
+
+  <!-- ============================================== -->
+  <!-- NODE 1: USER / DEVOPS                          -->
+  <!-- ============================================== -->
+  <g transform="translate(100, 200)">
+    <rect x="-30" y="-20" width="60" height="40" rx="4" fill="#1e293b" stroke="#cbd5e1" stroke-width="2"/>
+    <!-- Person Icon -->
+    <g transform="translate(0, -2)">
+      <!-- Head -->
+      <circle cx="0" cy="-6" r="6" fill="none" stroke="#38bdf8" stroke-width="2"/>
+      <!-- Body/Shoulders -->
+      <path d="M -10 10 Q -10 3, -6 3 L -3 3 Q 0 3, 0 5 Q 0 3, 3 3 L 6 3 Q 10 3, 10 10"
+            fill="none" stroke="#38bdf8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    <text x="0" y="45" fill="#f8fafc" font-family="sans-serif" font-size="13" font-weight="bold" text-anchor="middle">DevOps / Admin</text>
+  </g>
+
+
+  <!-- ============================================== -->
+  <!-- NODE 2: SAP AUTOMATION PILOT                   -->
+  <!-- ============================================== -->
+  <g transform="translate(400, 200)">
+    <!-- Main Box with pulse effect -->
+    <rect x="-70" y="-45" width="140" height="90" rx="12" fill="#0f172a" stroke="#8b5cf6" stroke-width="2">
+      <animate attributeName="stroke" values="#8b5cf6;#8b5cf6;#d8b4fe;#8b5cf6;#8b5cf6" keyTimes="0;0.19;0.25;0.35;1" dur="5s" repeatCount="indefinite"/>
+      <animate attributeName="stroke-width" values="2;2;4;2;2" keyTimes="0;0.19;0.25;0.35;1" dur="5s" repeatCount="indefinite"/>
+    </rect>
+    
+    <!-- Automation Pilot Logo Icon -->
+    <g transform="translate(0, -16)">
+      <defs>
+        <linearGradient id="apLogo0" x1="1.99008" y1="2.85702" x2="11.3367" y2="8.85798" gradientUnits="userSpaceOnUse">
+          <stop stop-color="#0195FF"/>
+          <stop offset="0.991028" stop-color="#1147E9"/>
+        </linearGradient>
+        <linearGradient id="apLogo1" x1="8.40832" y1="3.79682" x2="16.5056" y2="9.7828" gradientUnits="userSpaceOnUse">
+          <stop stop-color="#1348FF"/>
+          <stop offset="1" stop-color="#06238D"/>
+        </linearGradient>
+        <clipPath id="apClip">
+          <rect width="16" height="16" fill="white" transform="matrix(-1 0 0 1 15.9995 0.00195312)"/>
+        </clipPath>
+      </defs>
+
+      <g transform="translate(-20, -20) scale(2.5)" clip-path="url(#apClip)">
+        <!-- Pulse animation for active state -->
+        <g opacity="1">
+          <animate attributeName="opacity" values="1;1;0.7;1;1" keyTimes="0;0.19;0.25;0.35;1" dur="5s" repeatCount="indefinite"/>
+          <path d="M6.85703 0.661621H7.86059C8.20467 0.661621 8.52007 0.776313 8.8068 1.0057C9.07442 1.21597 9.2369 1.49314 9.29424 1.83722L9.49495 2.78343L9.99996 3.08878L9.54591 3.42704H9.15391C8.27025 3.42704 7.55391 4.14339 7.55391 5.02704C7.55391 5.04563 7.55423 5.06414 7.55486 5.08258C7.49473 5.07905 7.43416 5.07728 7.37315 5.07728C6.97173 5.07728 6.58942 5.15374 6.22623 5.30666C5.86304 5.45959 5.54763 5.66986 5.28002 5.93747C5.0124 6.20509 4.80213 6.51093 4.64921 6.85501C4.49629 7.2182 4.41983 7.60051 4.41983 8.00194C4.41983 8.40336 4.49629 8.77611 4.64921 9.12019C4.80213 9.48338 5.0124 9.79878 5.28002 10.0664C5.54763 10.334 5.86304 10.5443 6.22623 10.6972C6.58942 10.8501 6.97173 10.9266 7.37315 10.9266C7.4375 10.9266 7.50136 10.9246 7.56472 10.9207C7.55758 10.982 7.55391 11.0444 7.55391 11.1077C7.55391 11.9913 8.27026 12.7077 9.15391 12.7077H9.54591L9.903 12.9737L9.49495 13.2204L9.29424 14.1667C9.21778 14.5107 9.04574 14.7879 8.77813 14.9982C8.51051 15.2276 8.20467 15.3423 7.86059 15.3423H6.85703C6.51296 15.3423 6.20711 15.2276 5.9395 14.9982C5.67188 14.7879 5.49984 14.5107 5.42338 14.1667L5.25134 13.2204L3.98973 12.4749L3.12954 12.819C2.97662 12.8955 2.79502 12.9337 2.58475 12.9337C2.31713 12.9337 2.06864 12.8668 1.83925 12.733C1.59075 12.5992 1.3996 12.3985 1.26579 12.1309L0.749675 11.07C0.634983 10.8788 0.577637 10.659 0.577637 10.4105C0.577637 9.93259 0.778348 9.55028 1.17977 9.26355L1.86792 8.74744V7.25643L1.17977 6.76899C0.778348 6.46315 0.577637 6.07128 0.577637 5.59339C0.577637 5.36401 0.634983 5.14418 0.749675 4.93391L1.26579 3.87301C1.3996 3.60539 1.59075 3.40468 1.83925 3.27087C2.06864 3.13707 2.31713 3.07016 2.58475 3.07016C2.7759 3.07016 2.9575 3.09884 3.12954 3.15618L3.98973 3.52893L5.25134 2.78343L5.42338 1.83722C5.49984 1.49314 5.67188 1.21597 5.9395 1.0057C6.20711 0.776313 6.51296 0.661621 6.85703 0.661621Z" fill="url(#apLogo0)"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M12.2838 3.32229C12.5353 2.56364 13.2504 2.01636 14.0934 2.01636C15.1461 2.01636 15.9994 2.8697 15.9994 3.92235C15.9994 4.975 15.1461 5.82834 14.0934 5.82834C13.2504 5.82834 12.5352 5.28099 12.2838 4.52228H11.8391L10.5427 5.48815C10.4218 5.57817 10.2752 5.6268 10.1245 5.6268H9.23514C8.90377 5.6268 8.63514 5.35817 8.63514 5.0268C8.63514 4.69543 8.90377 4.4268 9.23514 4.4268H9.95869L11.2552 3.46094C11.376 3.37091 11.5227 3.32229 11.6734 3.32229H12.2838ZM13.3875 3.92235C13.3875 3.53244 13.7035 3.21635 14.0934 3.21635C14.4834 3.21635 14.7994 3.53244 14.7994 3.92235C14.7994 4.31225 14.4834 4.62834 14.0934 4.62834C13.7035 4.62834 13.3875 4.31225 13.3875 3.92235Z" fill="url(#apLogo1)"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M12.2838 12.8124C12.5353 13.5711 13.2504 14.1184 14.0934 14.1184C15.1461 14.1184 15.9994 13.265 15.9994 12.2124C15.9994 11.1597 15.1461 10.3064 14.0934 10.3064C13.2504 10.3064 12.5352 10.8537 12.2838 11.6124H11.8391L10.5426 10.6466C10.4218 10.5565 10.2751 10.5079 10.1244 10.5079H9.23513C8.90376 10.5079 8.63513 10.7765 8.63513 11.1079C8.63513 11.4393 8.90376 11.7079 9.23513 11.7079H9.95868L11.2552 12.6738C11.376 12.7638 11.5227 12.8124 11.6734 12.8124H12.2838ZM13.3874 12.2124C13.3874 12.6023 13.7035 12.9184 14.0934 12.9184C14.4833 12.9184 14.7994 12.6023 14.7994 12.2124C14.7994 11.8225 14.4833 11.5064 14.0934 11.5064C13.7035 11.5064 13.3874 11.8225 13.3874 12.2124Z" fill="url(#apLogo1)"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M11.7664 6.16137C10.9234 6.16137 10.2082 6.70865 9.95677 7.4673H7.69131C7.35994 7.4673 7.09131 7.73592 7.09131 8.06729C7.09131 8.39866 7.35994 8.66729 7.69131 8.66729H9.95673C10.2081 9.426 10.9233 9.97335 11.7664 9.97335C12.819 9.97335 13.6724 9.12 13.6724 8.06736C13.6724 7.01471 12.819 6.16137 11.7664 6.16137ZM11.7664 7.36136C11.3765 7.36136 11.0604 7.67745 11.0604 8.06736C11.0604 8.45726 11.3765 8.77335 11.7664 8.77335C12.1563 8.77335 12.4724 8.45726 12.4724 8.06736C12.4724 7.67745 12.1563 7.36136 11.7664 7.36136Z" fill="url(#apLogo1)"/>
+        </g>
+      </g>
+    </g>
+    
+    <text x="0" y="25" fill="#f8fafc" font-family="sans-serif" font-size="13" font-weight="bold" text-anchor="middle">Automation Pilot</text>
+    <text x="0" y="38" fill="#a78bfa" font-family="sans-serif" font-size="10" font-weight="bold" text-anchor="middle">SAP BTP</text>
+  </g>
+
+
+  <!-- ============================================== -->
+  <!-- TARGETS: HANA CLOUD DATABASES                  -->
+  <!-- ============================================== -->
+
+  <!-- SAP HANA Cloud Environment Boundary -->
+  <g id="hana-cloud-boundary">
+    <mask id="headerMask">
+      <rect x="580" y="10" width="210" height="370" rx="12" fill="white"/>
+    </mask>
+    
+    <!-- Background & Border -->
+    <rect x="580" y="10" width="210" height="370" rx="12" fill="#0f172a" stroke="#0ea5e9" stroke-width="1.5" stroke-dasharray="4 4" opacity="0.3"/>
+    <rect x="580" y="10" width="210" height="370" rx="12" fill="none" stroke="#0369a1" stroke-width="1"/>
+    
+    <!-- Header -->
+    <rect x="580" y="10" width="210" height="40" fill="#082f49" mask="url(#headerMask)" opacity="0.9"/>
+    <line x1="580" y1="50" x2="790" y2="50" stroke="#0369a1" stroke-width="1"/>
+
+    <!-- HANA Cloud Logo -->
+    <g transform="translate(590, 18)">
+      <defs>
+        <linearGradient id="hanaLogo0" x1="2.39845" y1="1.65497" x2="9.63519" y2="12.1351" gradientUnits="userSpaceOnUse">
+          <stop stop-color="#0195FF"/>
+          <stop offset="0.991028" stop-color="#1147E9"/>
+        </linearGradient>
+        <linearGradient id="hanaLogo1" x1="6.19063" y1="7.91088" x2="12.7405" y2="13.4628" gradientUnits="userSpaceOnUse">
+          <stop stop-color="#1348FF"/>
+          <stop offset="1" stop-color="#06238D"/>
+        </linearGradient>
+        <clipPath id="hanaClip">
+          <rect width="15.9998" height="15.9999" fill="white" transform="translate(0 0.0020752)"/>
+        </clipPath>
+      </defs>
+      <g transform="scale(1.5)" clip-path="url(#hanaClip)">
+        <path d="M3.60436 4.79248C3.43151 2.49608 5.27176 0.00219727 7.90081 0.00219727C9.93738 0.00219727 11.4318 1.23678 12.1451 3.15283C14.1233 3.01464 15.9999 4.69737 15.9999 7.11356C15.9999 8.65032 15.2696 9.81745 14.2142 10.4711V8.42665C14.2142 8.35407 14.2075 8.29646 14.2055 8.2799C14.2025 8.25424 14.1992 8.23255 14.1969 8.21803C14.1921 8.18854 14.1869 8.1614 14.1826 8.14035C14.1738 8.09745 14.1628 8.04965 14.1508 8.00316C14.1411 7.96575 14.1211 7.89137 14.0915 7.8129L14.0906 7.81056C14.0854 7.79668 14.071 7.7583 14.0465 7.7072C13.7067 6.81933 12.905 6.23949 12.112 5.89399C11.2389 5.51362 10.161 5.31502 9.01071 5.31502C7.86141 5.31502 6.78375 5.51211 5.90998 5.89172C5.09562 6.24552 4.27486 6.84481 3.94738 7.7695C3.87564 7.93479 3.80719 8.15938 3.80719 8.4314V11.0543H3.26608C1.11266 11.0543 0 9.73192 0 7.88328C0 5.9432 1.41701 4.41207 3.60436 4.79248Z" fill="url(#hanaLogo0)"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M9.01037 6.51514C11.0548 6.51514 12.6439 7.22667 12.9522 8.21332C12.9677 8.19789 13.0139 8.40062 13.0139 8.42678V13.953C13.0139 15.1199 11.292 16.0022 9.01037 16.0022C6.72873 16.0022 5.00684 15.1199 5.00684 13.953V8.43152C5.00684 8.35088 5.03055 8.27973 5.06376 8.21332C5.37683 7.22192 6.96591 6.51514 9.01037 6.51514ZM12.0652 8.56434C12.0652 8.12793 10.8461 7.46384 9.01037 7.46384C7.17463 7.46384 5.95554 8.12793 5.95554 8.56434C5.95554 9.00074 7.17463 9.66484 9.01037 9.66484C10.8461 9.66484 12.0652 9.00074 12.0652 8.56434ZM12.1805 11.0022C12.1805 10.6708 11.9119 10.4022 11.5805 10.4022C11.2491 10.4022 10.9805 10.6708 10.9805 11.0022V13.7751C10.9805 14.1065 11.2491 14.3751 11.5805 14.3751C11.9119 14.3751 12.1805 14.1065 12.1805 13.7751L12.1805 11.0022Z" fill="url(#hanaLogo1)"/>
+      </g>
+    </g>
+
+    <text x="625" y="36" fill="#f0f9ff" font-family="sans-serif" font-size="14" font-weight="bold" text-anchor="start">HANA Cloud</text>
+  </g>
+
+  <!-- DB 1: Start/Stop -->
+  <g transform="translate(660, 90)">
+    <!-- Success Pulse Effect -->
+    <circle cx="0" cy="0" r="35" fill="none" stroke="#0ea5e9" stroke-width="2" opacity="0">
+      <animate attributeName="opacity" values="0;0;0.8;0;0" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+      <animate attributeName="r" values="35;35;35;55;55" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+    </circle>
+    
+    <!-- DB Body -->
+    <path d="M -35 -20 L -35 20 A 35 12 0 0 0 35 20 L 35 -20 Z" fill="#1e293b" stroke="#0ea5e9" stroke-width="2">
+      <animate attributeName="fill" values="#1e293b;#1e293b;#334155;#1e293b;#1e293b" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+    </path>
+    <ellipse cx="0" cy="-20" rx="35" ry="12" fill="#0f172a" stroke="#0ea5e9" stroke-width="2"/>
+    
+    <!-- Power Icon -->
+    <g transform="translate(0, 10)" opacity="0.6" stroke="#e2e8f0">
+      <animate attributeName="opacity" values="0.6;0.6;1;0.6;0.6" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+      <animate attributeName="stroke" values="#e2e8f0;#e2e8f0;#38bdf8;#e2e8f0;#e2e8f0" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+      <path d="M 0 -6 L 0 2 M -4 -2 A 6 6 0 1 0 4 -2" fill="none" stroke-width="1.5" stroke-linecap="round"/>
+    </g>
+
+    <text x="50" y="3" fill="#38bdf8" font-family="sans-serif" font-size="12" font-weight="bold" text-anchor="start">
+      Start / Stop
+      <animate attributeName="fill" values="#38bdf8;#38bdf8;#bae6fd;#38bdf8;#38bdf8" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+    </text>
+  </g>
+
+  <!-- DB 2: Update HANA Cloud -->
+  <g transform="translate(660, 210)">
+    <!-- Success Pulse Effect -->
+    <circle cx="0" cy="0" r="35" fill="none" stroke="#0ea5e9" stroke-width="2" opacity="0">
+      <animate attributeName="opacity" values="0;0;0.8;0;0" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+      <animate attributeName="r" values="35;35;35;55;55" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- DB Body -->
+    <path d="M -35 -20 L -35 20 A 35 12 0 0 0 35 20 L 35 -20 Z" fill="#1e293b" stroke="#0ea5e9" stroke-width="2">
+      <animate attributeName="fill" values="#1e293b;#1e293b;#334155;#1e293b;#1e293b" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+    </path>
+    <ellipse cx="0" cy="-20" rx="35" ry="12" fill="#0f172a" stroke="#0ea5e9" stroke-width="2"/>
+
+    <!-- Update/Refresh Icon -->
+    <g transform="translate(0, 10)" opacity="0.6" stroke="#e2e8f0">
+      <animate attributeName="opacity" values="0.6;0.6;1;0.6;0.6" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+      <animate attributeName="stroke" values="#e2e8f0;#e2e8f0;#38bdf8;#e2e8f0;#e2e8f0" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+      
+      <path d="M 3.5 -3.5 A 5 5 0 1 1 -3.5 -3.5" fill="none" stroke-width="1.5" stroke-linecap="round"/>
+      
+      <path d="M -3.5 -1 L -3.5 -3.5 L -6 -3.5" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+
+    <text x="50" y="3" fill="#38bdf8" font-family="sans-serif" font-size="12" font-weight="bold" text-anchor="start">
+      Update
+      <animate attributeName="fill" values="#38bdf8;#38bdf8;#bae6fd;#38bdf8;#38bdf8" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+    </text>
+  </g>
+
+  <!-- DB 3: Scale Compute -->
+  <g transform="translate(660, 330)">
+    <!-- Success Pulse Effect -->
+    <circle cx="0" cy="0" r="35" fill="none" stroke="#0ea5e9" stroke-width="2" opacity="0">
+      <animate attributeName="opacity" values="0;0;0.8;0;0" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+      <animate attributeName="r" values="35;35;35;55;55" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- DB Body -->
+    <path d="M -35 -20 L -35 20 A 35 12 0 0 0 35 20 L 35 -20 Z" fill="#1e293b" stroke="#0ea5e9" stroke-width="2">
+      <animate attributeName="fill" values="#1e293b;#1e293b;#334155;#1e293b;#1e293b" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+    </path>
+    <ellipse cx="0" cy="-20" rx="35" ry="12" fill="#0f172a" stroke="#0ea5e9" stroke-width="2"/>
+    
+    <!-- Expand/Scale Icon -->
+    <g transform="translate(0, 10)" opacity="0.6" stroke="#e2e8f0">
+      <animate attributeName="opacity" values="0.6;0.6;1;0.6;0.6" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+      <animate attributeName="stroke" values="#e2e8f0;#e2e8f0;#38bdf8;#e2e8f0;#e2e8f0" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+      <path d="M -5 0 L 5 0 M -3 -2 L -5 0 L -3 2 M 3 -2 L 5 0 L 3 2" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+
+    <text x="50" y="3" fill="#38bdf8" font-family="sans-serif" font-size="12" font-weight="bold" text-anchor="start">
+      Scale
+      <animate attributeName="fill" values="#38bdf8;#38bdf8;#bae6fd;#38bdf8;#38bdf8" keyTimes="0;0.44;0.45;0.7;1" dur="5s" repeatCount="indefinite"/>
+    </text>
+  </g>
+
+</svg>

--- a/hana-lifecycle-management/catalog.json
+++ b/hana-lifecycle-management/catalog.json
@@ -1,0 +1,4298 @@
+{
+  "id": "hanalm-<<<TENANT_ID>>>",
+  "technicalName": "hanalm",
+  "name": "SAP HANA Cloud Lifecycle Management",
+  "description": "Lifecycle management commands for SAP HANA Cloud instances in Other Environment using Service Manager",
+  "owner": "<<<TENANT_ID>>>",
+  "tags": {},
+  "inputs": [],
+  "commands": [
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "targetTimestamp": "$(.execution.input.targetTimestamp)",
+          "targetInstanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "sourceInstanceId": "$(.execution.input.sourceInstanceId)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.targetInstanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "$(.execution.input.deadline)",
+              "parameters": "$({data: {requestedOperation: {name: \"SYSTEM_COPY\", arguments: {target_timestamp: .execution.input.targetTimestamp, source_instance_id: .execution.input.sourceInstanceId}}}})"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:CopyHanaCloudInstance:1",
+      "name": "CopyHanaCloudInstance",
+      "description": "Creates a copy of a HANA Cloud database instance at a given point in time to a new HANA Cloud database instance. Both instances will have the same software version. The source instance can be in the same or different subaccount. Note: Deleted instances can only be copied if both source and target are in the same subaccount. To copy to a different subaccount, you must provide the source instance UID.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "targetTimestamp": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The point-in-time timestamp to restore data from the source instance. Format: YYYY-MM-DD HH:MM:SS (e.g., 2025-05-25 16:13:43)"
+        },
+        "targetInstanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the target HANA Cloud instance that will receive the copy"
+        },
+        "sourceInstanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The identifier of the source HANA Cloud instance to copy from. Can be either the instance name or ID (GUID) when copying within the same subaccount. MUST be the ID (GUID/UID) when copying cross-subaccount"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        },
+        "deadline": {
+          "type": "number",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 1,
+          "maxValue": 1440,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "60",
+          "defaultValueFromInput": null,
+          "description": "Maximum time in minutes to wait for the copy operation to complete (default: 60, min: 1, max: 1440)"
+        }
+      },
+      "outputKeys": {
+        "targetTimestamp": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The point-in-time timestamp that was used to restore the data"
+        },
+        "targetInstanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the target instance that received the copy"
+        },
+        "sourceInstanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID/UID) of the source instance that was copied"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the target instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "ecnName": "$(.execution.input.ecnName)",
+          "memory": "$(.execution.input.memory)",
+          "vcpu": "$(.execution.input.vcpu)",
+          "storage": "$(.execution.input.storage)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:GetServiceInstanceParameters:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)"
+            },
+            "alias": "getInstanceParameters",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          },
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "30",
+              "parameters": "$({data: {computeNodes: ((.getInstanceParameters.output.parameters.computeNodes // []) + [{name: .execution.input.ecnName, vcpu: .execution.input.vcpu, memory: .execution.input.memory, storage: .execution.input.storage}])}})"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:CreateHanaCloudECN:1",
+      "name": "CreateHanaCloudECN",
+      "description": "Creates a single Elastic Compute Node (ECN) for a HANA Cloud database instance. ECNs provide additional compute resources for query processing.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "ecnName": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": 1,
+          "maxSize": 9,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Unique ECN name (1-9 chars, lowercase alphanumeric, must start with letter). Used for defining workergroups for table placement and query routing"
+        },
+        "memory": {
+          "type": "number",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 32,
+          "maxValue": 6144,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Memory in GB for the ECN. Available in 15 GB increments from 32 GB to 6 TB (max depends on cloud provider)"
+        },
+        "vcpu": {
+          "type": "number",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 1,
+          "maxValue": 120,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Number of virtual CPUs for the ECN (max depends on cloud provider: Azure/AWS 120, GCP 84)"
+        },
+        "storage": {
+          "type": "number",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 1,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Storage size in GB for the ECN"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "ecnName": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The name of the created ECN"
+        },
+        "memory": {
+          "type": "number",
+          "sensitive": false,
+          "description": "Memory in GB allocated to the ECN"
+        },
+        "vcpu": {
+          "type": "number",
+          "sensitive": false,
+          "description": "Number of vCPUs allocated to the ECN"
+        },
+        "storage": {
+          "type": "number",
+          "sensitive": false,
+          "description": "Storage in GB allocated to the ECN"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.createInstance.output.instanceId)",
+          "instanceName": "$(.createInstance.output.serviceInstance.name)",
+          "serviceInstance": "$(.createInstance.output.serviceInstance)",
+          "parameters": "$(.createInstance.output.parameters)",
+          "status": "$(.createInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:CreateServiceInstance:1",
+            "input": {
+              "service": "hana-cloud",
+              "displayName": "$(.execution.input.instanceName)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "$(.execution.input.deadline)",
+              "parameters": "$({data: ({memory: .execution.input.memory, slaLevel: .execution.input.slaLevel, storage: .execution.input.storage, systempassword: .execution.input.systemPassword, vcpu: .execution.input.vcpu, whitelistIPs: .execution.input.whitelistIPs} + (.execution.input.additionalParameters // {}))})",
+              "plan": "$(.execution.input.plan)",
+              "labels": "$(.execution.input.labels)"
+            },
+            "alias": "createInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:CreateHanaCloudInstance:1",
+      "name": "CreateHanaCloudInstance",
+      "description": "Provisions a new SAP HANA Cloud Database instance through Service Manager with the specified configuration including memory, storage, and network access settings.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "slaLevel": {
+          "type": "string",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": [
+            "standard",
+            "elevated"
+          ],
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "standard",
+          "defaultValueFromInput": null,
+          "description": "Service Level Agreement for the HANA Cloud instance. Determines availability guarantees and support level."
+        },
+        "memory": {
+          "type": "number",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 30,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Memory allocation in GB (minimum 30 GB). Common values: 30, 60, 120, 240, 480."
+        },
+        "systemPassword": {
+          "type": "string",
+          "sensitive": true,
+          "required": true,
+          "minSize": 8,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "DBADMIN password for the HANA Cloud instance. Must be at least 8 characters with 1 uppercase, 2 lowercase, and 1 number."
+        },
+        "instanceName": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The display name to assign to the HANA Cloud instance. Must be unique within the subaccount."
+        },
+        "vcpu": {
+          "type": "number",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 2,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Number of virtual CPUs to allocate (minimum 2). Typically calculated as memory/15 rounded up."
+        },
+        "whitelistIPs": {
+          "type": "array",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "[ ]",
+          "defaultValueFromInput": null,
+          "description": "Array of IP filter ranges in CIDR notation (e.g., ['203.0.113.0/24', '198.51.100.50/32']). Maximum 250 entries. Use empty array [] to allow access only from Cloud Foundry in the same region."
+        },
+        "additionalParameters": {
+          "type": "object",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "{ }",
+          "defaultValueFromInput": null,
+          "description": "Additional HANA Cloud configuration parameters to merge with core settings. Can include: edition (default 'cloud'), enabledservices (object), and other advanced configuration options."
+        },
+        "storage": {
+          "type": "number",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 120,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Storage allocation in GB (minimum 120 GB). Must be at least 4x the memory allocation."
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        },
+        "deadline": {
+          "type": "number",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 1,
+          "maxValue": 1440,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "30",
+          "defaultValueFromInput": null,
+          "description": "Maximum time in minutes to wait for instance creation to complete (default: 30, min: 1, max: 1440)"
+        },
+        "plan": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": [
+            "hana",
+            "hana-free"
+          ],
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "hana",
+          "defaultValueFromInput": null,
+          "description": "The service plan for the HANA Cloud instance. Determines the instance capabilities and pricing."
+        },
+        "labels": {
+          "type": "object",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Optional labels to attach to the instance for organization and filtering"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the created HANA Cloud service instance"
+        },
+        "instanceName": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The display name of the created HANA Cloud instance"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Complete Service Manager service instance object"
+        },
+        "parameters": {
+          "type": "object",
+          "sensitive": false,
+          "description": "The configuration parameters applied to the instance"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "createdAt": "$(.updateInstance.output.serviceInstance.updated_at)",
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "snapshotId": "$(.updateInstance.output.parameters.storageSnapshots[-1].snapshotId)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "$(.execution.input.deadline)",
+              "parameters": "{\"data\":{\"requestedOperation\":{\"name\":\"TAKE_SNAPSHOT_FOR_FALLBACK\"}}}"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:CreateHanaCloudSnapshot:1",
+      "name": "CreateHanaCloudSnapshot",
+      "description": "Creates a snapshot of the current HANA Cloud instance state, enabling rollback to this exact version before future upgrades. Snapshots are used exclusively for version rollback. Only one snapshot can exist per instance. The snapshot is automatically deleted after 14 days or when a rollback is performed. Snapshots incur additional storage costs.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        },
+        "deadline": {
+          "type": "number",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 1,
+          "maxValue": 1440,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "30",
+          "defaultValueFromInput": null,
+          "description": "Maximum time in minutes to wait for snapshot creation to complete (default: 30, min: 1, max: 1440)"
+        }
+      },
+      "outputKeys": {
+        "createdAt": {
+          "type": "string",
+          "sensitive": false,
+          "description": "Timestamp when the snapshot was created"
+        },
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "snapshotId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier of the created snapshot"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "totalCreated": "$(.execution.input.ecns | length)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "createdECNs": "$(.execution.input.ecns)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:GetServiceInstanceParameters:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)"
+            },
+            "alias": "getInstanceParameters",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          },
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "30",
+              "parameters": "$({data: {computeNodes: ((.getInstanceParameters.output.parameters.data.computeNodes // []) + .execution.input.ecns)}})"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:CreateMultipleHanaCloudECNs:1",
+      "name": "CreateMultipleHanaCloudECNs",
+      "description": "Creates multiple Elastic Compute Nodes (ECNs) for a HANA Cloud database instance in a single operation.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        },
+        "ecns": {
+          "type": "array",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Array of ECN objects to create. Each object must have: name (string, 1-9 chars), vcpu (number), memory (number, GB), storage (number, GB). Example: [{\"name\": \"ecn1\", \"vcpu\": 4, \"memory\": 120, \"storage\": 360}]"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "totalCreated": {
+          "type": "number",
+          "sensitive": false,
+          "description": "Total number of ECNs created in this operation"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "createdECNs": {
+          "type": "array",
+          "sensitive": false,
+          "description": "Array of ECN objects that were created"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "deletedCount": "$(.getInstanceParameters.output.parameters.data.computeNodes // [] | length)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:GetServiceInstanceParameters:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)"
+            },
+            "alias": "getInstanceParameters",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          },
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "30",
+              "parameters": "$({data: {computeNodes: []}})"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:DeleteAllHanaCloudECNs:1",
+      "name": "DeleteAllHanaCloudECNs",
+      "description": "Deletes all Elastic Compute Nodes (ECNs) from a HANA Cloud database instance. Use with caution as this operation cannot be undone.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "deletedCount": {
+          "type": "number",
+          "sensitive": false,
+          "description": "Total number of ECNs that were deleted"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "remainingECNs": "$(.getInstanceParameters.output.parameters.data.computeNodes | filter(.name != $.execution.input.ecnName))",
+          "deletedECNName": "$(.execution.input.ecnName)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:GetServiceInstanceParameters:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)"
+            },
+            "alias": "getInstanceParameters",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          },
+          {
+            "execute": "utils-sapcp:Void:1",
+            "input": {
+              "message": "$(\n    .getInstanceParameters.output.parameters.data.computeNodes\n    | filter(.name == $.execution.input.ecnName)\n    | .[-1].name\n)"
+            },
+            "alias": "validateECNExists",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": {
+              "semantic": "OR",
+              "conditions": [
+                {
+                  "semantic": "OR",
+                  "cases": [
+                    {
+                      "expression": "$(.validateECNExists.output.message | length)",
+                      "operator": "NOT_EQUALS",
+                      "semantic": "OR",
+                      "values": [
+                        "0"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [
+              {
+                "message": "ECN with name '$(.execution.input.ecnName)' does not exist on this instance",
+                "when": {
+                  "semantic": "OR",
+                  "conditions": [
+                    {
+                      "semantic": "OR",
+                      "cases": [
+                        {
+                          "expression": "$(.validateECNExists.output.message | length)",
+                          "operator": "EQUALS",
+                          "semantic": "OR",
+                          "values": [
+                            "0"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ],
+            "dryRun": null
+          },
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "30",
+              "parameters": "$({data: {computeNodes: (.getInstanceParameters.output.parameters.data.computeNodes | filter(.name != $.execution.input.ecnName))}})"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:DeleteHanaCloudECN:1",
+      "name": "DeleteHanaCloudECN",
+      "description": "Deletes a specific Elastic Compute Node (ECN) from a HANA Cloud database instance by name. All other ECNs remain active.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "ecnName": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": 1,
+          "maxSize": 9,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Name of the ECN to delete"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "remainingECNs": {
+          "type": "array",
+          "sensitive": false,
+          "description": "Array of remaining ECN objects after deletion"
+        },
+        "deletedECNName": {
+          "type": "string",
+          "sensitive": false,
+          "description": "Name of the ECN that was deleted"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "deletedInstanceId": "$(.deleteInstance.output.instanceId)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:DeleteServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "30"
+            },
+            "alias": "deleteInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:DeleteHanaCloudInstance:1",
+      "name": "DeleteHanaCloudInstance",
+      "description": "Permanently deletes a HANA Cloud instance and all its data. This operation is irreversible. Backups are retained according to the configured retention policy.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "deletedInstanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the deleted instance"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "deletedSnapshotId": "$(.execution.input.snapshotId)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "10",
+              "parameters": "$({data: {requestedOperation: {name: \"REMOVE_SNAPSHOT_FOR_FALLBACK\", arguments: {snapshot_id: .execution.input.snapshotId}}}})"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:DeleteHanaCloudSnapshot:1",
+      "name": "DeleteHanaCloudSnapshot",
+      "description": "Deletes a specific storage snapshot from a HANA Cloud instance. Snapshots are used for version rollback and are automatically deleted after 14 days. This command allows manual deletion of snapshots before the automatic expiration. Only one snapshot can exist per instance at a time.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "snapshotId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier of the snapshot to delete"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "deletedSnapshotId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier of the deleted snapshot"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "deletedSnapshotTimestamp": "$(.listSnapshots.output.snapshots | sort_by(.snapshotTimestamp) | .[0].snapshotTimestamp)",
+          "instanceId": "$(.deleteSnapshot.output.instanceId)",
+          "deletedSnapshotId": "$(.deleteSnapshot.output.deletedSnapshotId)",
+          "status": "$(.deleteSnapshot.output.status)"
+        },
+        "executors": [
+          {
+            "execute": "hanalm-<<<TENANT_ID>>>:ListHanaCloudSnapshots:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)"
+            },
+            "alias": "listSnapshots",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          },
+          {
+            "execute": "hanalm-<<<TENANT_ID>>>:DeleteHanaCloudSnapshot:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "snapshotId": "$(.listSnapshots.output.snapshots | sort_by(.snapshotTimestamp) | .[0].snapshotId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "10"
+            },
+            "alias": "deleteSnapshot",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": {
+              "semantic": "OR",
+              "conditions": [
+                {
+                  "semantic": "OR",
+                  "cases": [
+                    {
+                      "expression": "$(.listSnapshots.output.totalCount)",
+                      "operator": "GREATER_THAN",
+                      "semantic": "OR",
+                      "values": [
+                        "0"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:DeleteOldestHanaCloudSnapshot:1",
+      "name": "DeleteOldestHanaCloudSnapshot",
+      "description": "Deletes the oldest storage snapshot from a HANA Cloud instance based on the snapshot creation timestamp. This command retrieves all available snapshots, sorts them by timestamp, and removes the oldest one. Useful for managing storage costs by removing outdated snapshots while keeping more recent ones for version rollback.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "deletedSnapshotTimestamp": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The creation timestamp of the deleted snapshot"
+        },
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "deletedSnapshotId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier of the deleted snapshot"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "enabledServices": "$(.updateInstance.output.parameters.data.enabledservices)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "30",
+              "parameters": "$({ data: { enabledservices: ({ scriptserver: .execution.input.scriptserver, docstore: .execution.input.docstore, dpserver: .execution.input.dpserver, pal: .execution.input.pal, nlp: .execution.input.nlp, triplestore: .execution.input.triplestore } | filter(. != null)) }})"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:EnableHanaCloudCapabilities:1",
+      "name": "EnableHanaCloudCapabilities",
+      "description": "Enables or disables additional capabilities for a HANA Cloud database instance including scriptserver (for AFL execution), docstore (JSON document store), dpserver (Data Provisioning Server), pal (Predictive Analysis Library for Free Tier), nlp (text analysis and vector embeddings), and triplestore (RDF knowledge graphs). Note: scriptserver, docstore, and triplestore each require additional 16 GB memory.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "scriptserver": {
+          "type": "boolean",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Enable script server for Application Function Libraries (AFL) execution. Requires additional 16 GB memory. Used for PAL, APL, and product-specific AFLs"
+        },
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "nlp": {
+          "type": "boolean",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Enable text analysis and vector embedding functions to convert documents to dense embedding vectors"
+        },
+        "docstore": {
+          "type": "boolean",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Enable document store for native JSON data storage and processing. Requires additional 16 GB memory. Cannot be disabled via CLI (requires service request)"
+        },
+        "pal": {
+          "type": "boolean",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Enable limited Predictive Analysis Library (PAL) functionalities. Available for Free Tier instances only. When upgrading to Paid Tier, automatically adds script server (typically 3 vCPUs)"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        },
+        "triplestore": {
+          "type": "boolean",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Enable triple store for RDF knowledge graph storage and processing. Requires additional 16 GB memory"
+        },
+        "dpserver": {
+          "type": "boolean",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Enable Data Provisioning Server for native connectivity to many sources and Data Provisioning Agent. Runs as an index server variant in the HANA cluster"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "enabledServices": {
+          "type": "object",
+          "sensitive": false,
+          "description": "The updated configuration of enabled capabilities"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "whitelistIPs": "$(.execution.input.whitelistIPs)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "enabled": "$(.execution.input.enabled)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "10",
+              "parameters": "$({data: {extensionservices: [{name: \"ConnectivityProxy\", enabled: .execution.input.enabled, whitelistIPs: .execution.input.whitelistIPs}]}})"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:EnableHanaCloudConnectivityProxy:1",
+      "name": "EnableHanaCloudConnectivityProxy",
+      "description": "Enables or disables the Cloud Connector (ConnectivityProxy) feature for a HANA Cloud instance, allowing on-premise SAP HANA databases to connect to the HANA Cloud database via Cloud Connector to replicate data from on-premise to cloud.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "whitelistIPs": {
+          "type": "array",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": 250,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Array of IP filter ranges in CIDR notation (e.g., ['10.0.0.0/8', '172.16.0.0/12']) defining which on-premise systems can access the HANA Cloud instance. Maximum 250 entries including both IP addresses and ranges. Recommended: limit and control access to specific IP addresses for security. Empty array restricts access."
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials (plan: subaccount-admin)"
+        },
+        "enabled": {
+          "type": "boolean",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Whether to enable (true) or disable (false) the Cloud Connector connectivity proxy to allow on-premise SAP HANA systems to connect to this HANA Cloud instance"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "whitelistIPs": {
+          "type": "array",
+          "sensitive": false,
+          "description": "The configured IP filter ranges in CIDR notation for on-premise system access"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "enabled": {
+          "type": "boolean",
+          "sensitive": false,
+          "description": "Whether the Cloud Connector connectivity proxy is enabled for on-premise to cloud connectivity"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(if .execution.input.instanceId | isGuid then .execution.input.instanceId else .getInstanceId.output.instanceId end)",
+          "instanceName": "$(.getServiceInstance.output.serviceInstance.name)",
+          "serviceInstance": "$(.getServiceInstance.output.serviceInstance)",
+          "dashboard_url": "$(.getServiceInstance.output.serviceInstance.dashboard_url)",
+          "parameters": "$(.getServiceInstanceParameters.output.parameters)",
+          "status": "$(.getServiceInstance.output.serviceInstance.last_operation.state)",
+          "labels": "$(.getServiceInstance.output.serviceInstance.labels)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:GetServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)"
+            },
+            "alias": "getServiceInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          },
+          {
+            "execute": "sm-sapcp:GetServiceInstanceParameters:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)"
+            },
+            "alias": "getServiceInstanceParameters",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:GetHanaCloudInstance:1",
+      "name": "GetHanaCloudInstance",
+      "description": "Retrieves detailed information about a HANA Cloud instance including status, configuration parameters, labels, and connection details.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the HANA Cloud instance"
+        },
+        "instanceName": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The display name of the HANA Cloud instance"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Complete Service Manager service instance object"
+        },
+        "dashboard_url": {
+          "type": "string",
+          "sensitive": false,
+          "description": "URL to the HANA Cloud cockpit dashboard for this instance"
+        },
+        "parameters": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Instance configuration parameters including memory, storage, whitelistIPs, enabled services, etc."
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "Current operational status (RUNNING, STOPPED, CREATING, UPDATING, DELETING, etc.)"
+        },
+        "labels": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Instance labels and tags"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "installedPlugins": "$(.updateInstance.output.parameters.data.plugins)",
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "30",
+              "parameters": "$({data: {plugins: (.execution.input.plugins | map({name: .}))}})"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:InstallHanaCloudPlugins:1",
+      "name": "InstallHanaCloudPlugins",
+      "description": "Installs plugins for a HANA Cloud database instance. Plugins extend the functionality of the database with additional capabilities.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "plugins": {
+          "type": "array",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Array of plugin names to install. Example: [\"document-filters-library-1.0.5\"]"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "installedPlugins": {
+          "type": "array",
+          "sensitive": false,
+          "description": "Array of installed plugin objects"
+        },
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.getInstance.output.serviceInstance.id)",
+          "availableUpgradeVersions": "$(.getInstanceParameters.output.parameters.availableUpgradeVersions | map({ \"expiration-date\": .expiration-date, id, name, releaseCycle, track }))",
+          "currentVersion": "$(.getInstanceParameters.output.parameters.currentProductVersion | { \"expiration-date\": .expiration-date, id, name, releaseCycle, track })"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:GetServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)"
+            },
+            "alias": "getInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          },
+          {
+            "execute": "sm-sapcp:GetServiceInstanceParameters:1",
+            "input": {
+              "instanceId": "$(.getInstance.output.serviceInstance.id)",
+              "serviceKey": "$(.execution.input.serviceKey)"
+            },
+            "alias": "getInstanceParameters",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:ListHanaCloudAvailableUpgradeVersions:1",
+      "name": "ListHanaCloudAvailableUpgradeVersions",
+      "description": "Retrieves the current version and available upgrade versions for a HANA Cloud database instance. Use this command to check which versions you can upgrade to before performing an upgrade. The availableUpgradeVersions section shows eligible release cycles and tracks. Also returns maintenance status to indicate if current version is out of maintenance.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "availableUpgradeVersions": {
+          "type": "array",
+          "sensitive": false,
+          "description": "Array of available upgrade versions with release cycle and track information"
+        },
+        "currentVersion": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Current product version object containing id, name, releaseCycle, track, and maintenance status"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.getInstance.output.instanceId)",
+          "totalECNs": "$(.getInstance.output.parameters.data.computeNodes // [] | length)",
+          "ecns": "$(.getInstance.output.parameters.data.computeNodes // [] | map({ name, memory, vcpu, storage }))"
+        },
+        "executors": [
+          {
+            "execute": "hanalm-<<<TENANT_ID>>>:GetHanaCloudInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)"
+            },
+            "alias": "getInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:ListHanaCloudECNs:1",
+      "name": "ListHanaCloudECNs",
+      "description": "Retrieves all Elastic Compute Nodes (ECNs) configured for a HANA Cloud database instance. Returns ECN details including name, vCPU, memory, and storage configuration. ECNs provide additional compute resources for query processing.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "totalECNs": {
+          "type": "number",
+          "sensitive": false,
+          "description": "Total number of ECNs configured for this instance"
+        },
+        "ecns": {
+          "type": "array",
+          "sensitive": false,
+          "description": "Array of ECN objects, each containing name, vcpu, memory, and storage"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instances": "$(.listServiceInstances.output.serviceInstances)",
+          "nextPageToken": "$(.listServiceInstances.output.nextPageToken)",
+          "totalCount": "$(.listServiceInstances.output.totalResultsCount)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:GetServiceDetails:1",
+            "input": {
+              "service": "hana-cloud",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "plan": "$(.execution.input.plan)"
+            },
+            "alias": "getHanaServiceDetails",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          },
+          {
+            "execute": "sm-sapcp:ListServiceInstances:1",
+            "input": {
+              "pageSize": "$(.execution.input.pageSize)",
+              "fieldSelector": "service_plan_id eq '$(.getHanaServiceDetails.output.planId)'",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "pageToken": "$(.execution.input.pageToken)"
+            },
+            "alias": "listServiceInstances",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:ListHanaCloudInstances:1",
+      "name": "ListHanaCloudInstances",
+      "description": "Retrieves a list of all HANA Cloud service instances in the subaccount with their current status and basic metadata.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "pageSize": {
+          "type": "number",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 1,
+          "maxValue": 1000,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "100",
+          "defaultValueFromInput": null,
+          "description": "The maximum number of instances to return per page (default: 100)"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        },
+        "pageToken": {
+          "type": "string",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Page token for pagination. Leave empty to start from the beginning."
+        },
+        "plan": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": [
+            "hana",
+            "hana-free"
+          ],
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "hana",
+          "defaultValueFromInput": null,
+          "description": "The service plan to filter instances by. Only instances with this plan will be returned."
+        }
+      },
+      "outputKeys": {
+        "instances": {
+          "type": "array",
+          "sensitive": false,
+          "description": "Array of HANA Cloud instance summaries. Each element contains instanceId, instanceName, status, plan, created_at, and updated_at."
+        },
+        "nextPageToken": {
+          "type": "string",
+          "sensitive": false,
+          "description": "Token for retrieving the next page of results. Use this value as the pageToken input parameter in the next request. Empty if no more pages are available."
+        },
+        "totalCount": {
+          "type": "number",
+          "sensitive": false,
+          "description": "Total number of HANA Cloud instances found in the subaccount"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.getInstance.output.instanceId)",
+          "plugins": "$(.getInstance.output.parameters.data.plugins // [])",
+          "totalPlugins": "$(.getInstance.output.parameters.data.plugins // [] | length)"
+        },
+        "executors": [
+          {
+            "execute": "hanalm-<<<TENANT_ID>>>:GetHanaCloudInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)"
+            },
+            "alias": "getInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:ListHanaCloudPlugins:1",
+      "name": "ListHanaCloudPlugins",
+      "description": "Retrieves all installed plugins for a HANA Cloud database instance. Returns plugin details including name and status. Plugins extend the functionality of the database with additional capabilities.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "plugins": {
+          "type": "array",
+          "sensitive": false,
+          "description": "Array of plugin objects, each containing name and other plugin details"
+        },
+        "totalPlugins": {
+          "type": "number",
+          "sensitive": false,
+          "description": "Total number of plugins installed on this instance"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "snapshots": "$(.getInstanceParameters.output.parameters.storageSnapshots // [])",
+          "totalCount": "$(.getInstanceParameters.output.parameters.storageSnapshots // [] | length)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:GetServiceInstanceParameters:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)"
+            },
+            "alias": "getInstanceParameters",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:ListHanaCloudSnapshots:1",
+      "name": "ListHanaCloudSnapshots",
+      "description": "Retrieves all available storage snapshots for a HANA Cloud instance. Snapshots are used for version rollback and are automatically deleted after 14 days or when a rollback is performed. Each snapshot contains information about the HANA storage size, product version, snapshot ID, and creation timestamp.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "snapshots": {
+          "type": "array",
+          "sensitive": false,
+          "description": "Array of available storage snapshots, each containing snapshotId, snapshotTimestamp, hanaStorage, and productVersion details"
+        },
+        "totalCount": {
+          "type": "number",
+          "sensitive": false,
+          "description": "Total number of available snapshots"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "recoveryTimestamp": "$(.execution.input.targetTimestamp)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "$(.execution.input.deadline)",
+              "parameters": "{\"data\":{\"requestedOperation\":{\"name\":\"POINT_IN_TIME_RECOVERY\",\"arguments\":{\"target_timestamp\":\"$(.execution.input.targetTimestamp)\"}}}}"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:RecoverHanaCloudInstance:1",
+      "name": "RecoverHanaCloudInstance",
+      "description": "Restores a HANA Cloud instance to a specific point in time using available backups. HANA uses the most recent backup before the target timestamp and applies transaction logs to reach the exact recovery point.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "targetTimestamp": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Target recovery timestamp in format 'YYYY-MM-DD HH:MM:SS' (UTC). If you select a date in the future, then the database is restored to the latest available state."
+        },
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        },
+        "deadline": {
+          "type": "number",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 1,
+          "maxValue": 1440,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "60",
+          "defaultValueFromInput": null,
+          "description": "Maximum time in minutes to wait for recovery to complete (default: 60, min: 1, max: 1440)"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the recovered instance"
+        },
+        "recoveryTimestamp": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The timestamp to which the instance was recovered"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "targetAvailabilityZone": "$(.execution.input.targetAvailabilityZone)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "$(.execution.input.deadline)",
+              "parameters": "$(.execution.input.targetAvailabilityZone | if . then {data: {requestedOperation: {name: \"DISASTER_KEEP_AZ_RECOVERY\", arguments: {target_az: .}}}} else {data: {requestedOperation: {name: \"DISASTER_KEEP_AZ_RECOVERY\"}}} end)"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:RecreateHanaCloudInstanceFromBackup:1",
+      "name": "RecreateHanaCloudInstanceFromBackup",
+      "description": "Recreates a HANA Cloud database instance from its backup. This operation is used for disaster recovery scenarios. The instance can be recreated in the same availability zone as the original instance or in a different availability zone if specified.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "targetAvailabilityZone": {
+          "type": "string",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The logical availability zone name where the instance will be recreated (e.g., eu-central-1b). If not specified, the instance is recreated in the same zone as the original instance"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        },
+        "deadline": {
+          "type": "number",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 1,
+          "maxValue": 1440,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "60",
+          "defaultValueFromInput": null,
+          "description": "Maximum time in minutes to wait for the recreation operation to complete (default: 60, min: 1, max: 1440)"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the recreated instance"
+        },
+        "targetAvailabilityZone": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The availability zone where the instance was recreated (null if recreated in same zone as original)"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.startInstance.output.instanceId)",
+          "serviceInstance": "$(.startInstance.output.serviceInstance)",
+          "status": "$(.startInstance.output.status)"
+        },
+        "executors": [
+          {
+            "execute": "hanalm-<<<TENANT_ID>>>:StopHanaCloudInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)"
+            },
+            "alias": "stopInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          },
+          {
+            "execute": "hanalm-<<<TENANT_ID>>>:StartHanaCloudInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)"
+            },
+            "alias": "startInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:RestartHanaCloudInstance:1",
+      "name": "RestartHanaCloudInstance",
+      "description": "Restarts a HANA Cloud instance by stopping it and then starting it again. This is useful for applying configuration changes or troubleshooting. The operation combines stop and start operations, typically taking 10-15 minutes total.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the HANA Cloud instance"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object after restart"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "restoredFrom": "$(.execution.input.snapshotId)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "$(.execution.input.deadline)",
+              "parameters": "{\"data\":{\"requestedOperation\":{\"name\":\"FALLBACK_TO_SNAPSHOT\",\"arguments\":{\"snapshot_id\":\"$(.execution.input.snapshotId)\"}}}}"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:RevertHanaCloudToSnapshot:1",
+      "name": "RevertHanaCloudToSnapshot",
+      "description": "Reverts a HANA Cloud instance to a previously created snapshot, effectively rolling back to the prior HANA version and data state. This operation is typically used after a version upgrade that causes issues. The revert operation requires instance downtime and is irreversible - all changes made after the snapshot was taken are lost. The snapshot is automatically deleted after successful revert. This operation typically takes 20-40 minutes.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "snapshotId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier of the snapshot to restore. Must be a valid snapshot for this instance."
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        },
+        "deadline": {
+          "type": "number",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 1,
+          "maxValue": 1440,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "60",
+          "defaultValueFromInput": null,
+          "description": "Maximum time in minutes to wait for the revert operation to complete (default: 60, min: 1, max: 1440)"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "restoredFrom": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The snapshot ID that was used for restoration"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "30",
+              "parameters": "{\"data\": {\"serviceStopped\": false}}"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:StartHanaCloudInstance:1",
+      "name": "StartHanaCloudInstance",
+      "description": "Starts a HANA Cloud instance that is currently in STOPPED state. The operation typically takes 5-10 minutes to complete.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the HANA Cloud instance"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "secondaryAvailabilityZone": "$(.execution.input.secondaryAvailabilityZone)",
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "takeoverType": "$(.execution.input.takeoverType)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "$(.execution.input.deadline)",
+              "parameters": "$(.execution.input.secondaryAvailabilityZone | if . then {data: {requestedOperation: {name: .execution.input.takeoverType, arguments: {secondary_az: .}}}} else {data: {requestedOperation: {name: .execution.input.takeoverType}}} end)"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:StartHanaCloudInstanceTakeover:1",
+      "name": "StartHanaCloudInstanceTakeover",
+      "description": "Starts takeover for a HANA Cloud database instance. Supports both synchronous replication takeover (for synchronous replicas in different availability zones) and disaster recovery takeover (for asynchronous replicas in different availability zones). Use this command to failover to a replica in case of primary instance failure.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "secondaryAvailabilityZone": {
+          "type": "string",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The logical availability zone of the asynchronous replica (e.g., eu-central-1b). Required only for disaster_recovery_takeover"
+        },
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "takeoverType": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": [
+            "synchronous_replication_takeover",
+            "disaster_recovery_takeover"
+          ],
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Type of takeover to perform. synchronous_replication_takeover: for synchronous replicas. disaster_recovery_takeover: for asynchronous replicas"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        },
+        "deadline": {
+          "type": "number",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 1,
+          "maxValue": 1440,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "30",
+          "defaultValueFromInput": null,
+          "description": "Maximum time in minutes to wait for the takeover operation to complete (default: 30, min: 1, max: 1440)"
+        }
+      },
+      "outputKeys": {
+        "secondaryAvailabilityZone": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The availability zone of the secondary replica (null if not applicable)"
+        },
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "takeoverType": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The type of takeover that was performed"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "30",
+              "parameters": "{\"data\": {\"serviceStopped\": true}}"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:StopHanaCloudInstance:1",
+      "name": "StopHanaCloudInstance",
+      "description": "Stops a HANA Cloud instance that is currently in RUNNING state. This gracefully shuts down the database. Stopping reduces costs while preserving all data and configuration. The operation typically takes 2-5 minutes to complete.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the HANA Cloud instance"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "retentionDays": "$(.updateInstance.output.parameters.data.backup.retentionDays)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "10",
+              "parameters": "{   \"data\": {     \"backup\": {       \"retentionDays\": $(.execution.input.retentionDays)     }   } }"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:UpdateHanaCloudBackupSettings:1",
+      "name": "UpdateHanaCloudBackupSettings",
+      "description": "Updates the backup retention policy for a HANA Cloud instance, specifying how many days backups should be retained before automatic deletion. The retention period affects storage costs and point-in-time recovery capabilities. Changes apply to future backups; existing backups retain their original expiration dates.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "retentionDays": {
+          "type": "number",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 1,
+          "maxValue": 215,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "14",
+          "defaultValueFromInput": null,
+          "description": "Number of days to retain backups before automatic deletion. Range: 1-215 days. Longer retention increases storage costs."
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "retentionDays": {
+          "type": "number",
+          "sensitive": false,
+          "description": "The configured backup retention period in days"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "ecnName": "$(.execution.input.ecnName)",
+          "memory": "$(.execution.input.memory)",
+          "vcpu": "$(.execution.input.vcpu)",
+          "storage": "$(.execution.input.storage)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:GetServiceInstanceParameters:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)"
+            },
+            "alias": "getInstanceParameters",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          },
+          {
+            "execute": "utils-sapcp:Void:1",
+            "input": {
+              "message": "$(\n    .getInstanceParameters.output.parameters.data.computeNodes\n    | filter(.name == $.execution.input.ecnName)\n    | .[-1].name\n)"
+            },
+            "alias": "validateECNExists",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": {
+              "semantic": "OR",
+              "conditions": [
+                {
+                  "semantic": "OR",
+                  "cases": [
+                    {
+                      "expression": "$(.validateECNExists.output.message | length)",
+                      "operator": "NOT_EQUALS",
+                      "semantic": "OR",
+                      "values": [
+                        "0"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [
+              {
+                "message": "ECN with name '$(.execution.input.ecnName)' does not exist on this instance",
+                "when": {
+                  "semantic": "OR",
+                  "conditions": [
+                    {
+                      "semantic": "OR",
+                      "cases": [
+                        {
+                          "expression": "$(.validateECNExists.output.message | length)",
+                          "operator": "EQUALS",
+                          "semantic": "OR",
+                          "values": [
+                            "0"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ],
+            "dryRun": null
+          },
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "30",
+              "parameters": "$({data: {computeNodes: (.getInstanceParameters.output.parameters.data.computeNodes | map(if .name == $.execution.input.ecnName then {name: $.execution.input.ecnName, vcpu: $.execution.input.vcpu, memory: $.execution.input.memory, storage: $.execution.input.storage} else . end))}})"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:UpdateHanaCloudECN:1",
+      "name": "UpdateHanaCloudECN",
+      "description": "Updates the configuration (vCPU, memory, storage) of an existing Elastic Compute Node (ECN) for a HANA Cloud database instance. This operation modifies the resource allocation for the specified ECN. Note that ECN names cannot be changed. Memory is available in 15 GB increments from 32 GB to 6 TB.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "ecnName": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": 1,
+          "maxSize": 9,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Name of the ECN to update (must match existing ECN name)"
+        },
+        "memory": {
+          "type": "number",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 32,
+          "maxValue": 6144,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "New memory in GB for the ECN. Available in 15 GB increments from 32 GB to 6 TB"
+        },
+        "vcpu": {
+          "type": "number",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 1,
+          "maxValue": 120,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "New number of virtual CPUs for the ECN (max depends on cloud provider: Azure/AWS 120, GCP 84)"
+        },
+        "storage": {
+          "type": "number",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 1,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "New storage size in GB for the ECN"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "ecnName": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The name of the updated ECN"
+        },
+        "memory": {
+          "type": "number",
+          "sensitive": false,
+          "description": "Updated memory in GB for the ECN"
+        },
+        "vcpu": {
+          "type": "number",
+          "sensitive": false,
+          "description": "Updated number of vCPUs for the ECN"
+        },
+        "storage": {
+          "type": "number",
+          "sensitive": false,
+          "description": "Updated storage in GB for the ECN"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "whitelistIPs": "$(.updateInstance.output.parameters.data.whitelistIPs)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "10",
+              "parameters": "$({data: {whitelistIPs: .execution.input.whitelistIPs}})"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:UpdateHanaCloudInstanceAllowedConnections:1",
+      "name": "UpdateHanaCloudInstanceAllowedConnections",
+      "description": "Configures the IP filter rules that control which IP addresses and ranges can connect to the HANA Cloud instance. Changes take effect immediately without requiring instance restart. An empty whitelist allows access only from Cloud Foundry applications in the same region.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "whitelistIPs": {
+          "type": "array",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": 250,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Array of IP filter ranges in CIDR notation (e.g., ['203.0.113.0/24', '198.51.100.50/32']). Maximum 250 entries. Empty array restricts access to Cloud Foundry in same region only."
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the instance"
+        },
+        "whitelistIPs": {
+          "type": "array",
+          "sensitive": false,
+          "description": "The updated IP filter ranges in CIDR notation"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "memory": "$(.updateInstance.output.parameters.data.memory)",
+          "vcpu": "$(.updateInstance.output.parameters.data.vcpu)",
+          "storage": "$(.updateInstance.output.parameters.data.storage)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "$(.execution.input.deadline)",
+              "parameters": "$({ data: ({ memory: .execution.input.memory, vcpu: .execution.input.vcpu, storage: .execution.input.storage } | filter(. != null)) })"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:UpdateHanaCloudInstanceSize:1",
+      "name": "UpdateHanaCloudInstanceSize",
+      "description": "Modifies the compute and storage resources allocated to a HANA Cloud instance. Memory and vCPU changes require instance downtime (automatic restart). Storage can only be increased, never decreased. The operation typically takes 10-20 minutes to complete.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "memory": {
+          "type": "number",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "New memory allocation in GB (e.g., 30, 60, 120, 240). Requires instance restart."
+        },
+        "vcpu": {
+          "type": "number",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "New vCPU count. Requires instance restart."
+        },
+        "storage": {
+          "type": "number",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "New storage allocation in GB. Can only be increased, never decreased. Requires instance restart."
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        },
+        "deadline": {
+          "type": "number",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 1,
+          "maxValue": 1440,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "30",
+          "defaultValueFromInput": null,
+          "description": "Maximum time in minutes to wait for the resize operation to complete (default: 30, min: 1, max: 1440)"
+        }
+      },
+      "outputKeys": {
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the resized instance"
+        },
+        "memory": {
+          "type": "number",
+          "sensitive": false,
+          "description": "Current memory allocation in GB"
+        },
+        "vcpu": {
+          "type": "number",
+          "sensitive": false,
+          "description": "Current vCPU count"
+        },
+        "storage": {
+          "type": "number",
+          "sensitive": false,
+          "description": "Current storage allocation in GB"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    },
+    {
+      "configuration": {
+        "values": [],
+        "output": {
+          "versionId": "$(.findApplicableVersion.output.message)",
+          "instanceId": "$(.updateInstance.output.serviceInstance.id)",
+          "serviceInstance": "$(.updateInstance.output.serviceInstance)",
+          "track": "$(.execution.input.track)",
+          "releaseCycle": "$(.execution.input.releaseCycle)",
+          "status": "$(.updateInstance.output.serviceInstance.last_operation.state)"
+        },
+        "executors": [
+          {
+            "execute": "sm-sapcp:GetServiceInstanceParameters:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)"
+            },
+            "alias": "getInstanceParameters",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          },
+          {
+            "execute": "utils-sapcp:Void:1",
+            "input": {
+              "message": "$(\n    .getInstanceParameters.output.parameters.availableUpgradeVersions\n    | filter(.releaseCycle == $.execution.input.releaseCycle and .track == $.execution.input.track)\n    | .[-1].id\n)"
+            },
+            "alias": "findApplicableVersion",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": {
+              "semantic": "OR",
+              "conditions": [
+                {
+                  "semantic": "OR",
+                  "cases": [
+                    {
+                      "expression": "$(.findApplicableVersion.output.message | length)",
+                      "operator": "NOT_EQUALS",
+                      "semantic": "OR",
+                      "values": [
+                        "0"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [
+              {
+                "message": "No matching upgrade version found for releaseCycle '$(.execution.input.releaseCycle)' and track '$(.execution.input.track)'",
+                "when": {
+                  "semantic": "OR",
+                  "conditions": [
+                    {
+                      "semantic": "OR",
+                      "cases": [
+                        {
+                          "expression": "$(.findApplicableVersion.output.message | length)",
+                          "operator": "EQUALS",
+                          "semantic": "OR",
+                          "values": [
+                            "0"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ],
+            "dryRun": null
+          },
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.instanceId)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "$(.execution.input.deadline)",
+              "parameters": "$({data: { update_strategy: .execution.input.updateStrategy, productVersion: {id: .findApplicableVersion.output.message, releaseCycle: .execution.input.releaseCycle, track: .execution.input.track}}})"
+            },
+            "alias": "updateInstance",
+            "description": null,
+            "progressMessage": null,
+            "initialDelay": null,
+            "pause": null,
+            "when": null,
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          }
+        ],
+        "listeners": []
+      },
+      "id": "hanalm-<<<TENANT_ID>>>:UpgradeHanaCloudInstance:1",
+      "name": "UpgradeHanaCloudInstance",
+      "description": "Upgrades a HANA Cloud database instance to a newer version within a release cycle and track. The Quarterly Release Cycle (generally-available-quarterly) is the default option. New QRC versions are released every three months. You cannot downgrade after upgrade. Patches are provided for up to 7 months per QRC version. Instances on out-of-maintenance QRC versions will be automatically upgraded.",
+      "catalog": "hanalm-<<<TENANT_ID>>>",
+      "version": 1,
+      "inputKeys": {
+        "updateStrategy": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": [
+            "with_restart",
+            "without_restart"
+          ],
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Upgrade strategy: with_restart requires instance restart during upgrade, without_restart performs upgrade with minimal downtime"
+        },
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The unique identifier (GUID) or display name of the HANA Cloud instance"
+        },
+        "serviceKey": {
+          "type": "object",
+          "sensitive": true,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "Service Manager service key containing authentication credentials"
+        },
+        "track": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The release track (version within release cycle) eligible for patches. Example: 2022.14 (QRC 2/2022). Check availableUpgradeVersions in instance parameters to see eligible tracks"
+        },
+        "deadline": {
+          "type": "number",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": 1,
+          "maxValue": 1440,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "60",
+          "defaultValueFromInput": null,
+          "description": "Maximum time in minutes to wait for the upgrade operation to complete (default: 60, min: 1, max: 1440)"
+        },
+        "releaseCycle": {
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": null,
+          "defaultValueFromInput": null,
+          "description": "The release cycle of the SAP HANA database. Example: generally-available-quarterly (default for most accounts). Availability depends on your account configuration"
+        }
+      },
+      "outputKeys": {
+        "versionId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The version ID that was used for the upgrade (resolved from releaseCycle and track)"
+        },
+        "instanceId": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The unique identifier (GUID) of the upgraded instance"
+        },
+        "serviceInstance": {
+          "type": "object",
+          "sensitive": false,
+          "description": "Updated Service Manager service instance object"
+        },
+        "track": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The release track (version) used for the upgrade"
+        },
+        "releaseCycle": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The release cycle used for the upgrade"
+        },
+        "status": {
+          "type": "string",
+          "sensitive": false,
+          "description": "The operational status of the instance (should be 'succeeded' upon success)"
+        }
+      },
+      "tags": {}
+    }
+  ]
+}

--- a/scc-connection-status/README.md
+++ b/scc-connection-status/README.md
@@ -44,7 +44,7 @@ To use this example you'll need the following:
       }
   }
   ```
-* **Cloud Connector Setup in Cloud ALM**: Configure your Cloud Connector in Cloud ALM by following this [guide](https://support.sap.com/en/alm/sap-cloud-alm/operations/expert-portal/setup-managed-services/setup-cloud-connector.html?anchorId=section_369985517_co).
+* **Cloud Connector Setup in Cloud ALM**: Configure your Cloud Connector in Cloud ALM by following this [guide](https://help.sap.com/docs/cloud-alm/setup-administration/cloud-connector?locale=en-US).
   * Once configured, use the resulting service ID from Landscape Management.
   * ![Cloud ALM Landscape Management service ID highlight](./assets/calm-service-id.png)
 

--- a/script-http-request/README.md
+++ b/script-http-request/README.md
@@ -19,7 +19,7 @@ Automation Pilot enables such scenarios with the [*ExecuteScript*](https://help.
 
 The supported runtimes include bash, python, node.js and provides access to popular CLI tools including curl, jq, and git.
 
-This example command has very similar contract to the original *HttpRequest*. However, its implementation is base entirely on *ExecuteScript* by utilizing [curl](https://curl.se/) and [jq](https://stedolan.github.io/jq/). It could be used to send requests to slow synchronous APIs and to work with larger response bodies.
+This example command has very similar contract to the original *HttpRequest*. However, its implementation is base entirely on *ExecuteScript* by utilizing [curl](https://curl.se/) and [jq](https://github.com/jqlang/jq/). It could be used to send requests to slow synchronous APIs and to work with larger response bodies.
 
 :warning: *ExecuteScript* has [some limitations](https://help.sap.com/docs/AUTOMATION_PILOT/de3900c419f5492a8802274c17e07049/d0854dbb80d84946bb57791db94b7e20.html) described in the documentation. They also apply to this example command.
 
@@ -41,7 +41,7 @@ You'll need to provide values for the following input keys:
 * *user* - Optional: User name to use for server authentication
 * *password* - Optional: Password to use for server authentication
 * *authorizationHeader* - Optional: Explicit value for the HTTP authorization header. Overwrites all other forms of authentication
-* *responseBodyTransformer* - Optional: JQ expression to transform the response body with. The format must follow the one described in <https://github.com/stedolan/jq>
+* *responseBodyTransformer* - Optional: JQ expression to transform the response body with. The format must follow the one described in <https://github.com/jqlang/jq>
 
 ## Expected result
 

--- a/script-http-request/catalog.json
+++ b/script-http-request/catalog.json
@@ -89,7 +89,7 @@
           "suggestedValuesFromInputKeys": null,
           "defaultValue": null,
           "defaultValueFromInput": null,
-          "description": "A JQ expression to transform the response body with. The format must follow the one described in https://github.com/stedolan/jq"
+          "description": "A JQ expression to transform the response body with. The format must follow the one described in https://github.com/jqlang/jq"
         },
         "method": {
           "type": "string",


### PR DESCRIPTION
This catalog provides comprehensive lifecycle management commands for SAP HANA Cloud instances using Service Manager API, including:
- Instance operations (create, delete, start, stop, restart, copy)
- Backup & recovery management
- Snapshot operations (create, list, delete, revert)
- Configuration updates (size, connections, backup settings)
- Version upgrades and plugin management
- Elastic Compute Node (ECN) operations

The example includes an interactive SVG diagram showing key automation scenarios:
- Schedule start/stop instances for cost optimization
- Update HANA Cloud instances with maintenance automation
- Scale compute resources dynamically

Features 31 commands covering all aspects of HANA Cloud lifecycle automation.