### PR TITLE
Add NZDM (without restart) update strategy to Update HANA Cloud example

### DIFF
--- a/update-hana-cloud/README.md
+++ b/update-hana-cloud/README.md
@@ -19,10 +19,13 @@ The command in this example executes the following steps:
 
 * Checks if an update is available based on the chosen update strategy.
 * Optionally, pauses and awaits explicit confirmation before performing the update.
+* If enabled, configures the NZDM (Near Zero Downtime Maintenance) update strategy to perform the update without restart.
 * Executes the update to the available version.
 * If no suitable version is available, the execution terminates without proceeding any further.
 
-Typically, an update requires the database to restart, resulting in downtime. Given this, the command pauses prior to the update until explicit confirmation is received from your DevOps team. If downtime is not an issue, or the database is configured to be updated without a restart, this confirmation can be disabled. For more information, visit this page: [Upgrading Without Restart](https://help.sap.com/docs/HANA_CLOUD/9ae9104a46f74a6583ce5182e7fb20cb/c26e42e6a7a4411191441c8d48fd9b11.html)
+Typically, an update requires the database to restart, resulting in downtime. Given this, the command pauses prior to the update until explicit confirmation is received from your DevOps team. If downtime is not an issue, this confirmation can be disabled.
+
+Additionally, HANA Cloud databases support the NZDM (Near Zero Downtime Maintenance) option which performs the update without a restart. When enabled, a new replica is created on the fly to aid with the update, avoiding downtime. This can be activated by setting the *withoutRestart* input to *true*. For more information, visit this page: [Upgrading Without Restart](https://help.sap.com/docs/HANA_CLOUD/9ae9104a46f74a6583ce5182e7fb20cb/c26e42e6a7a4411191441c8d48fd9b11.html)
 
 :warning: Please note: It is not possible to revert to a previous version once the upgrade is complete. We strongly advise verifying everything works as expected on a test system prior to applying the update to the production environment.
 
@@ -68,6 +71,7 @@ You'll need to provide values for the following input keys:
 * *password* - Password of your technical user
 * *identityProvider* - Optional: origin key of your identity provider. Defaults to sap.ids
 * *makeSnapshotBeforeUpdate* - Optional: Whether to make a snapshot of the HANA instance before updating. If there is existing snapshot you will be asked if you want to delete it. Note there can be only one snapshot and it gets deleted in 14 days. Defaults to false
+* *withoutRestart* - Optional: Whether to update without restart (NZDM). When enabled, a new replica is created on the fly to aid with the update, avoiding downtime. Defaults to false
 * *shouldConfirmBeforeUpdate* - Optional: whether to require confirmation before starting the update, if there's one available. Defaults to true
 * *shouldConfirmSnapshotDelete* - Does nothing if *makeSnapshotBeforeUpdate* is set to false. Whether to pause the execution when creating snapshot and another one already exists. If set to false no confirmation will be required to delete existing snapshot.
 
@@ -97,6 +101,7 @@ You'll need to provide values for the following input keys:
 * *hanaCloudInstance* - Name of your HANA Cloud service instance
 * *serviceKey* - Service key to the SAP Service Manager, plan subaccount-admin
 * *makeSnapshotBeforeUpdate* - Optional: Whether to make a snapshot of the HANA instance before updating. If there is existing snapshot you will be asked if you want to delete it. Note there can be only one snapshot and it gets deleted in 14 days. Defaults to false
+* *withoutRestart* - Optional: Whether to update without restart (NZDM). When enabled, a new replica is created on the fly to aid with the update, avoiding downtime. Defaults to false
 * *shouldConfirmBeforeUpdate* - Optional: whether to require confirmation before starting the update, if there's one available. Defaults to true
 * *shouldConfirmSnapshotDelete* - Does nothing if *makeSnapshotBeforeUpdate* is set to false. Whether to pause the execution when creating snapshot and another one already exists. If set to false no confirmation will be required to delete existing snapshot.
 

--- a/update-hana-cloud/catalog.json
+++ b/update-hana-cloud/catalog.json
@@ -396,8 +396,7 @@
           "description": "The ID of the created snapshot."
         }
       },
-      "tags": {},
-      "issues": []
+      "tags": {}
     },
     {
       "configuration": {
@@ -652,8 +651,7 @@
           "description": "The ID of the created snapshot."
         }
       },
-      "tags": {},
-      "issues": []
+      "tags": {}
     },
     {
       "configuration": {
@@ -890,8 +888,7 @@
         }
       },
       "outputKeys": {},
-      "tags": {},
-      "issues": []
+      "tags": {}
     },
     {
       "configuration": {
@@ -1035,8 +1032,7 @@
         }
       },
       "outputKeys": {},
-      "tags": {},
-      "issues": []
+      "tags": {}
     },
     {
       "configuration": {
@@ -1289,6 +1285,69 @@
             "dryRun": null
           },
           {
+            "execute": "cf-sapcp:UpdateCfServiceInstance:1",
+            "input": {
+              "password": "$(.execution.input.password)",
+              "org": "$(.execution.input.org)",
+              "serviceInstance": "$(.execution.input.hanaCloudInstance)",
+              "region": "$(.execution.input.region)",
+              "deadline": "180",
+              "user": "$(.execution.input.user)",
+              "parameters": "{\"data\":{\"update_strategy\":\"$(if .execution.input.withoutRestart then \"without_restart\" else \"with_restart\" end)\"}}",
+              "space": "$(.execution.input.space)",
+              "identityProvider": "$(.execution.input.identityProvider)"
+            },
+            "alias": "ConfigureNZDM",
+            "description": null,
+            "progressMessage": "Configured NZDM (without restart) for the HANA Cloud database update",
+            "initialDelay": null,
+            "pause": null,
+            "when": {
+              "semantic": "AND",
+              "conditions": [
+                {
+                  "semantic": "AND",
+                  "cases": [
+                    {
+                      "expression": "$(.DetermineVersion.output.message | length)",
+                      "operator": "NOT_EQUALS",
+                      "semantic": "OR",
+                      "values": [
+                        "0"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "semantic": "OR",
+                  "cases": [
+                    {
+                      "expression": "$(.ConfirmUpdate.output.selection)",
+                      "operator": "EQUALS",
+                      "semantic": "OR",
+                      "values": [
+                        "confirm"
+                      ]
+                    },
+                    {
+                      "expression": "$(.execution.input.shouldConfirmBeforeUpdate)",
+                      "operator": "EQUALS",
+                      "semantic": "OR",
+                      "values": [
+                        "false"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          },
+          {
             "execute": "dblm-sapcp:UpdateHanaCloudInstance:1",
             "input": {
               "resourceGroup": "$(.execution.input.space)",
@@ -1358,7 +1417,7 @@
       },
       "id": "examples-<<<TENANT_ID>>>:UpdateHanaCloudDatabaseCF:1",
       "name": "UpdateHanaCloudDatabaseCF",
-      "description": "Update your HANA Cloud databases on Cloud Foundry to either the next QRC, latest QRC, or the most recent patch version. The command automatically determines and applies the appropriate update based on user's selection.",
+      "description": "Update your HANA Cloud databases on Cloud Foundry to either the next QRC, latest QRC, or the most recent patch version. The command automatically determines and applies the appropriate update based on user's selection. Optionally supports NZDM (without restart) update strategy.",
       "catalog": "examples-<<<TENANT_ID>>>",
       "version": 1,
       "inputKeys": {
@@ -1543,6 +1602,22 @@
           "defaultValue": "true",
           "defaultValueFromInput": null,
           "description": "Whether to require confirmation before starting the update, if there's one available"
+        },
+        "withoutRestart": {
+          "type": "boolean",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "false",
+          "defaultValueFromInput": null,
+          "description": "Whether to update without restart (NZDM). When enabled, a new replica is created on the fly to aid with the update, avoiding downtime."
         }
       },
       "outputKeys": {
@@ -1555,8 +1630,7 @@
       "tags": {
         "feature:logs": "",
         "env": "cf"
-      },
-      "issues": []
+      }
     },
     {
       "configuration": {
@@ -1804,6 +1878,64 @@
               "instanceId": "$(.execution.input.hanaCloudInstance)",
               "serviceKey": "$(.execution.input.serviceKey)",
               "deadline": "180",
+              "parameters": "{\"data\":{\"update_strategy\":\"$(if .execution.input.withoutRestart then \"without_restart\" else \"with_restart\" end)\"}}"
+            },
+            "alias": "ConfigureNZDM",
+            "description": null,
+            "progressMessage": "Configured NZDM (without restart) for the HANA Cloud database update",
+            "initialDelay": null,
+            "pause": null,
+            "when": {
+              "semantic": "AND",
+              "conditions": [
+                {
+                  "semantic": "AND",
+                  "cases": [
+                    {
+                      "expression": "$(.DetermineVersion.output.message | length)",
+                      "operator": "NOT_EQUALS",
+                      "semantic": "OR",
+                      "values": [
+                        "0"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "semantic": "OR",
+                  "cases": [
+                    {
+                      "expression": "$(.ConfirmUpdate.output.selection)",
+                      "operator": "EQUALS",
+                      "semantic": "OR",
+                      "values": [
+                        "confirm"
+                      ]
+                    },
+                    {
+                      "expression": "$(.execution.input.shouldConfirmBeforeUpdate)",
+                      "operator": "EQUALS",
+                      "semantic": "OR",
+                      "values": [
+                        "false"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "validate": null,
+            "autoRetry": null,
+            "repeat": null,
+            "errorMessages": [],
+            "dryRun": null
+          },
+          {
+            "execute": "sm-sapcp:UpdateServiceInstance:1",
+            "input": {
+              "instanceId": "$(.execution.input.hanaCloudInstance)",
+              "serviceKey": "$(.execution.input.serviceKey)",
+              "deadline": "180",
               "parameters": "{\"data\":{\"productVersion\":{\"releaseCycle\":\"$(.DetermineVersion.output.message | toObject.releaseCycle)\",\"track\":\"$(.DetermineVersion.output.message | toObject.releaseTrack)\",\"id\":\"$(.DetermineVersion.output.message | toObject.version)\"}}}"
             },
             "alias": "Update",
@@ -1861,7 +1993,7 @@
       },
       "id": "examples-<<<TENANT_ID>>>:UpdateHanaCloudDatabaseOtherEnv:1",
       "name": "UpdateHanaCloudDatabaseOtherEnv",
-      "description": "Update your HANA Cloud databases on Other Env (Subaccount level) to either the next QRC, latest QRC, or the most recent patch version. The command automatically determines and applies the appropriate update based on user's selection.",
+      "description": "Update your HANA Cloud databases on Other Env (Subaccount level) to either the next QRC, latest QRC, or the most recent patch version. The command automatically determines and applies the appropriate update based on user's selection. Optionally supports NZDM (without restart) update strategy.",
       "catalog": "examples-<<<TENANT_ID>>>",
       "version": 1,
       "inputKeys": {
@@ -1964,6 +2096,22 @@
           "defaultValue": "true",
           "defaultValueFromInput": null,
           "description": "Whether to require confirmation before starting the update, if there's one available"
+        },
+        "withoutRestart": {
+          "type": "boolean",
+          "sensitive": false,
+          "required": false,
+          "minSize": null,
+          "maxSize": null,
+          "minValue": null,
+          "maxValue": null,
+          "allowedValues": null,
+          "allowedValuesFromInputKeys": null,
+          "suggestedValues": null,
+          "suggestedValuesFromInputKeys": null,
+          "defaultValue": "false",
+          "defaultValueFromInput": null,
+          "description": "Whether to update without restart (NZDM). When enabled, a new replica is created on the fly to aid with the update, avoiding downtime."
         }
       },
       "outputKeys": {
@@ -1976,8 +2124,7 @@
       "tags": {
         "feature:logs": "",
         "env": "cf"
-      },
-      "issues": []
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds support for the NZDM (Near Zero Downtime Maintenance) update strategy to both CF and Other Env HANA Cloud update commands
- New `withoutRestart` boolean input (defaults to false) configures the update to avoid downtime by creating a replica on the fly
- Updated README documentation explaining the NZDM option